### PR TITLE
Panosfunk/fixing leave study

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -242,7 +242,7 @@ SPEC CHECKSUMS:
   package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   pedometer: 381969883680ade42559782cc41a3bbd453d8234
-  permission_handler_apple: 036b856153a2b1f61f21030ff725f3e6fece2b78
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   polar: 8efdf64c1b4e0034e8fa3b1d12b64e5b27a877f1
   PolarBleSdk: 2551160f3dcba0207723fc466a275e2d3aeda01f
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825

--- a/lib/blocs/app_bloc.dart
+++ b/lib/blocs/app_bloc.dart
@@ -369,14 +369,14 @@ class StudyAppBLoC extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Leave the study and also sign out the user.
+  /// Sign user out and leave the study.
   ///
   /// This entails everything from the [leaveStudy] method plus permanently
   /// deleting all user authentication information from this phone, including
   /// the authentication and refresh tokens.
-  Future<void> leaveStudyAndSignOut() async {
-    await leaveStudy();
+  Future<void> signOutAndLeaveStudy() async {
     await backend.signOut();
+    await leaveStudy();
     notifyListeners();
   }
 }

--- a/lib/carp_study_app.dart
+++ b/lib/carp_study_app.dart
@@ -19,6 +19,7 @@ class CarpStudyApp extends StatefulWidget {
 class CarpStudyAppState extends State<CarpStudyApp> {
   /// The landing page once the onboarding process is done.
   static const String firstRoute = StudyPage.route;
+  static const String homeRoute = '/';
 
   /// Reload language translations and re-build the entire app.
   void reloadLocale() => setState(() => rpLocalizationsDelegate.reload());
@@ -26,7 +27,7 @@ class CarpStudyAppState extends State<CarpStudyApp> {
   // This create the routing in the entire app.
   // Each page (like [LoginPage]) know the name of its own route.
   final GoRouter _router = GoRouter(
-    initialLocation: '/',
+    initialLocation: homeRoute,
     navigatorKey: _rootNavigatorKey,
     errorBuilder: (context, state) => const ErrorPage(),
     routes: <RouteBase>[
@@ -44,7 +45,7 @@ class CarpStudyAppState extends State<CarpStudyApp> {
           // Once the above is done, then show the "first route", which currently is
           // the "study" information page.
           GoRoute(
-              path: '/',
+              path: homeRoute,
               parentNavigatorKey: _shellNavigatorKey,
               redirect: (context, state) {
                 if (bloc.deploymentMode != DeploymentMode.local) {

--- a/lib/ui/pages/audio_task_page.dart
+++ b/lib/ui/pages/audio_task_page.dart
@@ -348,7 +348,7 @@ class AudioTaskPageState extends State<AudioTaskPage> {
             TextButton(
               child: Text(locale.translate("YES")),
               onPressed: () {
-                context.pushReplacement('/');
+                context.pushReplacement(CarpStudyAppState.homeRoute);
               },
             )
           ],

--- a/lib/ui/pages/error_page.dart
+++ b/lib/ui/pages/error_page.dart
@@ -19,7 +19,7 @@ class ErrorPage extends StatelessWidget {
             ),
             const SizedBox(height: 16.0),
             ElevatedButton(
-              onPressed: () => context.go('/'),
+              onPressed: () => context.go(CarpStudyAppState.homeRoute),
               child: const Text('Go back'),
             ),
           ],

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -136,7 +136,7 @@ class HomePageState extends State<HomePage> {
         context.go(DeviceListPage.route);
         break;
       case -1:
-        context.go('/');
+        context.go(CarpStudyAppState.homeRoute);
         break;
     }
   }

--- a/lib/ui/pages/informed_consent_page.dart
+++ b/lib/ui/pages/informed_consent_page.dart
@@ -15,7 +15,7 @@ class InformedConsentState extends State<InformedConsentPage> {
   void resultCallback(RPTaskResult result) {
     widget.model.informedConsentHasBeenAccepted(result);
     if (context.mounted) {
-      context.go('/');
+      context.go(CarpStudyAppState.homeRoute);
     }
   }
 
@@ -30,7 +30,7 @@ class InformedConsentState extends State<InformedConsentPage> {
           (document) {
             if (document == null) {
               bloc.hasInformedConsentBeenAccepted = true;
-              context.go('/');
+              context.go(CarpStudyAppState.homeRoute);
             }
             return document;
           },

--- a/lib/ui/pages/login_page.dart
+++ b/lib/ui/pages/login_page.dart
@@ -41,7 +41,7 @@ class _LoginPageState extends State<LoginPage> {
             child: TextButton(
               onPressed: () async {
                 await bloc.backend.authenticate();
-                if (context.mounted) context.go('/');
+                if (context.mounted) context.go(CarpStudyAppState.homeRoute);
               },
               child: Text(
                 locale.translate("pages.login.login"),

--- a/lib/ui/pages/message_details_page.dart
+++ b/lib/ui/pages/message_details_page.dart
@@ -36,7 +36,7 @@ class MessageDetailsPage extends StatelessWidget {
                       if (context.canPop()) {
                         context.pop();
                       } else {
-                        context.go('/');
+                        context.go(CarpStudyAppState.homeRoute);
                       }
                     },
                     icon: const Icon(Icons.close_rounded))

--- a/lib/ui/pages/profile_page.dart
+++ b/lib/ui/pages/profile_page.dart
@@ -261,14 +261,15 @@ class ProfilePageState extends State<ProfilePage> {
             ),
             TextButton(
                 child: Text(locale.translate("YES")),
-                onPressed: () => context.pop(true))
+                onPressed: () async {
+                  if (context.mounted) {
+                    await bloc.leaveStudy();
+                    context.go(InvitationListPage.route);
+                  }
+                }),
           ],
         );
       },
-    ).then((value) {
-      if (value == true) {
-        bloc.leaveStudy().then((_) => context.go(InvitationListPage.route));
-      }
-    });
+    );
   }
 }

--- a/lib/ui/pages/profile_page.dart
+++ b/lib/ui/pages/profile_page.dart
@@ -226,22 +226,21 @@ class ProfilePageState extends State<ProfilePage> {
           actions: <Widget>[
             TextButton(
               child: Text(locale.translate("NO")),
-              onPressed: () => context.pop(false),
+              onPressed: () => context.pop(),
             ),
             TextButton(
-              child: Text(locale.translate("YES")),
-              onPressed: () {
-                context.pop(true);
-              },
-            )
+                child: Text(locale.translate("YES")),
+                onPressed: () async {
+                  if (context.mounted) {
+                    await bloc.signOutAndLeaveStudy();
+                    context.pop();
+                    context.go(CarpStudyAppState.homeRoute);
+                  }
+                }),
           ],
         );
       },
-    ).then((value) {
-      if (value == true) {
-        bloc.leaveStudyAndSignOut().then((_) => context.go('/'));
-      }
-    });
+    );
   }
 
   Future<void> _showLeaveStudyConfirmationDialog() {
@@ -257,13 +256,14 @@ class ProfilePageState extends State<ProfilePage> {
           actions: <Widget>[
             TextButton(
               child: Text(locale.translate("NO")),
-              onPressed: () => context.pop(false),
+              onPressed: () => context.pop(),
             ),
             TextButton(
                 child: Text(locale.translate("YES")),
                 onPressed: () async {
                   if (context.mounted) {
                     await bloc.leaveStudy();
+                    context.pop();
                     context.go(InvitationListPage.route);
                   }
                 }),

--- a/lib/ui/pages/study_details_page.dart
+++ b/lib/ui/pages/study_details_page.dart
@@ -29,7 +29,7 @@ class StudyDetailsPage extends StatelessWidget {
               Row(mainAxisAlignment: MainAxisAlignment.end, children: [
                 IconButton(
                     onPressed: () =>
-                        context.canPop() ? context.pop() : context.replace('/'),
+                        context.canPop() ? context.pop() : context.replace(CarpStudyAppState.homeRoute),
                     icon: const Icon(Icons.close))
               ]),
               Flexible(

--- a/lib/ui/pages/study_details_page.dart
+++ b/lib/ui/pages/study_details_page.dart
@@ -28,8 +28,9 @@ class StudyDetailsPage extends StatelessWidget {
             children: [
               Row(mainAxisAlignment: MainAxisAlignment.end, children: [
                 IconButton(
-                    onPressed: () =>
-                        context.canPop() ? context.pop() : context.replace(CarpStudyAppState.homeRoute),
+                    onPressed: () => context.canPop()
+                        ? context.pop()
+                        : context.replace(CarpStudyAppState.homeRoute),
                     icon: const Icon(Icons.close))
               ]),
               Flexible(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -737,10 +737,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
+      sha256: "5b1726fee554d1cc9db1baef8061b126567ff0a1140a03ed7de936e62f2ab98b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.1"
+    version: "6.2.0"
   graphs:
     dependency: transitive
     description:
@@ -1948,4 +1948,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.2"
+  flutter: ">=3.19.0"


### PR DESCRIPTION
Fixed 'Log out' and 'Leave Study' button functionality in the 'Profile' page.

Inside the app_bloc.dart the leaveStudyAndSignOut() function should be signOutAndLeaveStudy() and user should be signed out first and then removed from the study, because otherwise, in iOS we would remove the user from the study, but then they had the option to select 'Cancel' logout in a dialog shown by iOS itself. 

Also updated '/' path to be a variable inside carp_study_app.dart like every other relative path for every page in the app.