### PR TITLE
Improve About (announcements) page

### DIFF
--- a/lib/blocs/app_bloc.dart
+++ b/lib/blocs/app_bloc.dart
@@ -264,7 +264,7 @@ class StudyAppBLoC extends ChangeNotifier {
   Future<void> refreshMessages() async {
     try {
       _messages = await messageManager.getMessages();
-      _messages.sort((m1, m2) => m1.timestamp.compareTo(m2.timestamp));
+      _messages.sort((m1, m2) => m2.timestamp.compareTo(m1.timestamp));
       info('Message list refreshed - count: ${_messages.length}');
     } catch (error) {
       warning('Error getting messages - $error');

--- a/lib/ui/pages/study_page.dart
+++ b/lib/ui/pages/study_page.dart
@@ -99,17 +99,7 @@ class StudyPageState extends State<StudyPage> {
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 8.0),
                 child: Text(
-                    '${locale.translate(message.type.toString().split('.').last.toLowerCase())} - ${timeago.format(
-                      DateTime.now().copyWithAdditional(
-                          years: -DateTime.now().year + message.timestamp.year,
-                          months:
-                              -DateTime.now().month + message.timestamp.month,
-                          days: -DateTime.now().day + message.timestamp.day,
-                          hours: -DateTime.now().hour + message.timestamp.hour,
-                          minutes: -DateTime.now().minute +
-                              message.timestamp.minute),
-                      locale: Localizations.localeOf(context).languageCode,
-                    )}',
+                    '${locale.translate(message.type.toString().split('.').last.toLowerCase())} - ${timeago.format(message.timestamp.toLocal())}',
                     style: aboutCardSubtitleStyle.copyWith(
                         color: Theme.of(context).primaryColor)),
               ),

--- a/lib/view_models/study_page_model.dart
+++ b/lib/view_models/study_page_model.dart
@@ -64,7 +64,7 @@ class StudyPageViewModel extends ViewModel {
         title: title,
         message: description,
         type: MessageType.announcement,
-        timestamp: DateTime.now(),
+        timestamp: bloc.studyStartTimestamp ?? DateTime.now(),
         image: 'assets/images/kids.png',
       );
 }


### PR DESCRIPTION
## Changelog
- Fix ordering of announcements - newest ones now show at the top
- Fix timestamp for when the announcement was posted
  - previously announcements posted "just now" would show as "2 hours ago" because it was using UTC time. Now, we convert it to local timezone
- Make the "pinned" announcement (study description) show the time from when the study was joined

![image](https://github.com/cph-cachet/carp_studies_app/assets/10660846/4cb1716a-bbf8-4681-b99f-15368996aff8)

Closes #280 and closes #269