### PR TITLE
Bump iOS minimum deployment version to 14.0 

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -34,10 +34,10 @@ PODS:
     - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
-  - flutter_sound (9.4.17):
+  - flutter_sound (9.4.20):
     - Flutter
-    - flutter_sound_core (= 9.4.17)
-  - flutter_sound_core (9.4.17)
+    - flutter_sound_core (= 9.4.20)
+  - flutter_sound_core (9.4.20)
   - flutter_timezone (0.0.1):
     - Flutter
   - geolocator_apple (1.2.0):
@@ -236,8 +236,8 @@ SPEC CHECKSUMS:
   flutter_blue_plus: 4837da7d00cf5d441fdd6635b3a57f936778ea96
   flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  flutter_sound: fbc83e9f79f42482eb414bc3d39267ea4a37a7f4
-  flutter_sound_core: f29684f1c6503599a8c560659036e2d851abc67f
+  flutter_sound: a1b685d17b758e65c20042293f98d4706b30e211
+  flutter_sound_core: 88bf854ed00a7a2d816307260db254c1c81b0b09
   flutter_timezone: ffb07bdad3c6276af8dada0f11978d8a1f8a20bb
   geolocator_apple: 6cbaf322953988e009e5ecb481f07efece75c450
   health: 5a380c0f6c4f619535845992993964293962e99e

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -423,7 +423,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -445,6 +445,7 @@
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "CARP Studies";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -557,7 +558,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -606,7 +607,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -630,6 +631,7 @@
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "CARP Studies";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -662,6 +664,7 @@
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "CARP Studies";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -269,10 +269,10 @@ packages:
     dependency: "direct main"
     description:
       name: carp_mobile_sensing
-      sha256: "8d371939d46e91bd96141fc558a1f35f64d81e3555176250efd39a25d0ca1d19"
+      sha256: e7e902ffbca2af6d8651bd0494dde3ae1f2262ab129ab12a3865d56ecd04fba0
       url: "https://pub.dev"
     source: hosted
-    version: "1.7.2"
+    version: "1.8.0"
   carp_movesense_package:
     dependency: "direct main"
     description:
@@ -719,26 +719,26 @@ packages:
     dependency: transitive
     description:
       name: flutter_sound
-      sha256: "22f13af5cacf48380318851997e4c29251fd0602a26fa6f07f7685c7e1e63699"
+      sha256: "07734206e8ffad4fdb517128a0331f8e9dd7b92fa12234ea8d9d09ca764a3445"
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.18"
+    version: "9.4.20"
   flutter_sound_platform_interface:
     dependency: transitive
     description:
       name: flutter_sound_platform_interface
-      sha256: "9637cad39c8d60e25ebdfc4fd06188976f43f577be4d8c51c3e4f086d58da30a"
+      sha256: "58cd12ea08131fb8d0c80097444f3814ee639638c8f78035abd8e1f998043b4e"
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.18"
+    version: "9.4.20"
   flutter_sound_web:
     dependency: transitive
     description:
       name: flutter_sound_web
-      sha256: "1a070a7114548e1b93b668843e65142dbb8f132ed6a2a0ad2d6a64e093039d25"
+      sha256: "68c295694a9cf6e5a67abf0e738e58534741a2f28c7812c10b0e1d46efcd44f2"
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.18"
+    version: "9.4.20"
   flutter_svg:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Referring to #304, the `HKElectrocardiogramQuery` class is only available on iOS 14.0+ (see: https://developer.apple.com/documentation/healthkit/hkelectrocardiogramquery)

Therefore, I have bumped the minimum deployment version to 14.0 so that HealthKit can work again.

Closes #304